### PR TITLE
Configure hatch to use virtualenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ Source = "https://github.com/Matter-Tech/matter-observability"
 path = "matter_observability/__about__.py"
 
 [tool.hatch.envs.default]
+type = "virtual"
+path= "venv"
 dependencies = [
     "matter-observability",
     "fastapi",


### PR DESCRIPTION
Make hatch create a virtualenv under the venv directory. This makes PyCharm recognise it and load the correct interpreter.