### PR TITLE
Use prometheus-fastapi-instrumentator instead of starlette-exporter

### DIFF
--- a/matter_observability/__about__.py
+++ b/matter_observability/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Rômulo Jales <romulo@thisismatter.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "1.6.0"
+__version__ = "2.0.0"

--- a/matter_observability/__about__.py
+++ b/matter_observability/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Rômulo Jales <romulo@thisismatter.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "2.0.0"
+__version__ = "1.7.0"

--- a/matter_observability/config.py
+++ b/matter_observability/config.py
@@ -2,7 +2,7 @@ import os
 
 
 class Config:
-    ENABLE_METRICS = os.getenv("ENABLE_METRICS", "true").lower() == "true"
+    ENABLE_METRICS = os.getenv("ENABLE_METRICS", "true").lower() == "true"  # Used by prometheus-fastapi-instrumentator
     SERVER_LOG_LEVEL = os.getenv("SERVER_LOG_LEVEL", "info")
     PROMETHEUS_PUSH_GATEWAY_HOST = os.getenv("PROMETHEUS_PUSH_GATEWAY_HOST")
     INSTANCE_NAME = os.getenv("INSTANCE_NAME")

--- a/matter_observability/fastapi/utils.py
+++ b/matter_observability/fastapi/utils.py
@@ -10,8 +10,6 @@ def configure_middleware(app: FastAPI, skip_paths: list[str] | None = None) -> N
 
     app.middleware("http")(process_request_id)
 
-    Instrumentator(
-        excluded_handlers=skip_paths,
-        should_respect_env_var=True,
-        env_var_name="ENABLE_METRICS"
-    ).instrument(app=app).expose(app=app, endpoint=metrics_path)
+    Instrumentator(excluded_handlers=skip_paths, should_respect_env_var=True, env_var_name="ENABLE_METRICS").instrument(
+        app=app
+    ).expose(app=app, endpoint=metrics_path)

--- a/matter_observability/fastapi/utils.py
+++ b/matter_observability/fastapi/utils.py
@@ -7,7 +7,7 @@ from matter_observability.exceptions import MisConfigurationError
 from .request_id import process_request_id
 
 
-def configure_middleware(app: FastAPI, skip_paths: list[str] | None = None) -> None:
+def configure_middleware(app: FastAPI) -> None:
     metrics_path = "/internal/metrics"
 
     app.middleware("http")(process_request_id)

--- a/matter_observability/fastapi/utils.py
+++ b/matter_observability/fastapi/utils.py
@@ -1,19 +1,17 @@
 from fastapi import FastAPI
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from matter_observability.config import Config
-from matter_observability.exceptions import MisConfigurationError
-
 from .request_id import process_request_id
 
 
-def configure_middleware(app: FastAPI) -> None:
+def configure_middleware(app: FastAPI, skip_paths: list[str] | None = None) -> None:
     metrics_path = "/internal/metrics"
+    skip_paths = skip_paths or [metrics_path]
 
     app.middleware("http")(process_request_id)
 
-    if Config.ENABLE_METRICS:
-        if bool(Config.INSTANCE_NAME) is False:
-            raise MisConfigurationError("Environment variable: INSTANCE_NAME is not valid")
-
-        Instrumentator().instrument(app=app).expose(app=app, endpoint=metrics_path)
+    Instrumentator(
+        excluded_handlers=skip_paths,
+        should_respect_env_var=True,
+        env_var_name="ENABLE_METRICS"
+    ).instrument(app=app).expose(app=app, endpoint=metrics_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ path= "venv"
 dependencies = [
     "matter-observability",
     "fastapi",
+    "prometheus-fastapi-instrumentator",
     "pytest",
     "pytest-cov",
     "pytest-asyncio",

--- a/tests/fastapi/test_configure_middleware.py
+++ b/tests/fastapi/test_configure_middleware.py
@@ -1,18 +1,21 @@
+from unittest.mock import Mock
+
 import pytest
 from fastapi import FastAPI
-from starlette_exporter import PrometheusMiddleware
+from pytest_mock import MockerFixture
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from matter_observability.exceptions import MisConfigurationError
 from matter_observability.fastapi import configure_middleware
 
 
-def test_configure_middleware_throws_exception_if_enable_metrics_is_not_set(mocker):
+def test_configure_middleware_throws_exception_if_enable_metrics_is_not_set(mocker: MockerFixture):
     mocker.patch("matter_observability.config.Config.INSTANCE_NAME", None)
     with pytest.raises(MisConfigurationError):
         configure_middleware(FastAPI())
 
 
-def test_configure_middlewares_does_not_add_prometheus_middleware_if_enable_metrics_is_not_set(mocker):
+def test_configure_middlewares_does_not_add_prometheus_middleware_if_enable_metrics_is_not_set(mocker: MockerFixture):
     mocker.patch("matter_observability.config.Config.ENABLE_METRICS", False)
 
     app = FastAPI()
@@ -23,12 +26,15 @@ def test_configure_middlewares_does_not_add_prometheus_middleware_if_enable_metr
     app.add_middleware.assert_called_once()
 
 
-def test_configure_middlewares_happy_path(mocker):
+def test_configure_middlewares_happy_path(mocker: MockerFixture):
     app = FastAPI()
-    app.add_middleware = mocker.Mock()
+    mocker.patch.object(FastAPI, "add_middleware")
+    instrumentator_mock = Mock
+    mocker.patch(f"{configure_middleware.__module__}.Instrumentator", return_value=instrumentator_mock)
+    instrumentator_mock.instrument = Mock(return_value=instrumentator_mock)
+    instrumentator_mock.expose = Mock(return_value=instrumentator_mock)
 
     configure_middleware(app)
 
-    app.add_middleware.assert_called_with(
-        PrometheusMiddleware, app_name="observability_instance", group_paths=True, skip_paths=["/internal/metrics"]
-    )
+    instrumentator_mock.instrument.assert_called_once_with(app=app)
+    instrumentator_mock.expose.assert_called_once_with(app=app, endpoint="/internal/metrics")

--- a/tests/fastapi/test_configure_middleware.py
+++ b/tests/fastapi/test_configure_middleware.py
@@ -1,18 +1,9 @@
 from unittest.mock import Mock
 
-import pytest
 from fastapi import FastAPI
 from pytest_mock import MockerFixture
-from prometheus_fastapi_instrumentator import Instrumentator
 
-from matter_observability.exceptions import MisConfigurationError
 from matter_observability.fastapi import configure_middleware
-
-
-def test_configure_middleware_throws_exception_if_enable_metrics_is_not_set(mocker: MockerFixture):
-    mocker.patch("matter_observability.config.Config.INSTANCE_NAME", None)
-    with pytest.raises(MisConfigurationError):
-        configure_middleware(FastAPI())
 
 
 def test_configure_middlewares_does_not_add_prometheus_middleware_if_enable_metrics_is_not_set(mocker: MockerFixture):


### PR DESCRIPTION
The former produces a richer set of metrics by default.