### PR TITLE
Add info on a required env variable for API metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ Make sure that you have set the following ENV values:
 SERVER_LOG_LEVEL=debug
 PROMETHEUS_PUSH_GATEWAY_HOST=localhost
 INSTANCE_NAME=observability_instance
+ENABLE_METRICS=true
 ```
+The last one is required for the API metrics endpoint to be exposed - they are not enabled by default!
 
 
 ## Contributing
@@ -169,6 +171,7 @@ Make sure you have all supported python versions installed in your machine:
 
 * 3.10
 * 3.11
+* 3.12
 
 ### Install hatch in your system
 


### PR DESCRIPTION
I forgot to include this piece of information in the `README` in #32 